### PR TITLE
Fix submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pydbg"]
-	path = pydbg
-	url = ./pydbg

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pydbg"]
+	path = pydbg
+	url = https://github.com/OpenRCE/pydbg


### PR DESCRIPTION
Paimei has for years had its .gitmodules file pointing at  a nonexistent pydbg install.
this should fix it
